### PR TITLE
Add links on how to set up email forwarding

### DIFF
--- a/docs/programs/email-forwarding.md
+++ b/docs/programs/email-forwarding.md
@@ -45,3 +45,8 @@ When a hacker discovers a vulnerability and sends their finding in an email to s
 
 *Note: You can add multiple email addresses to forward to the same inbox.* 
 ![email-forwarding-9](./images/email-forwarding-9.png)
+
+How to set up email forwarding for:
+- [Microsoft Outlook 365](https://support.office.com/en-US/article/Forward-email-to-another-email-account-1ED4EE1E-74F8-4F53-A174-86B748FF6A0E)
+- [Microsoft Exchange Server](https://technet.microsoft.com/en-us/library/dd351134(v=exchg.141).aspx)
+- [G Suite (formerly Google Apps)](https://support.google.com/a/answer/175745?hl=en)


### PR DESCRIPTION
This is useful information that was present on our old site but doesn't show up on our new site. Adding it back as a resource so customers can use this as a guide.