### PR TITLE
Only run tests for Node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 
-os:
-  - linux
-  - osx
-
 node_js:
   - "8"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ os:
   - osx
 
 node_js:
-  - "node"
-  - "lts/*"
-  - "7"
   - "8"
 
 script:


### PR DESCRIPTION
This should speed up the Travis builds a lot as it only has to test 1 node version. Waiting 30 minutes for a simple CI build isn't normal.