### PR TITLE
CSS changes for adding colored blockquotes

### DIFF
--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -483,11 +483,13 @@ blockquote {
   margin-left: 1.45rem;
   margin-right: 1.45rem;
   margin-top: 0;
-  padding-bottom: 0;
-  padding-left: 0;
-  padding-right: 0;
-  padding-top: 0;
+  padding-bottom: 12px;
+  padding-left: 12px;
+  padding-right: 4px;
+  padding-top: 12px;
   margin-bottom: 1.45rem;
+  background-color: #C5FFE8;
+  border-left: 6px solid #02C996;
 }
 
 form {


### PR DESCRIPTION
@lbekkema  I've been learning some CSS and HTML and Javascript and wanted to implement some of it onto the docs site! Here's a code change for the CSS for blockquotes. Previously when I experimented and deployed the code changes, the docs site either completely broke or the styling completely went wonky for the entire site. If my code is correct, how do I deploy the changes without breaking the site? 