### PR TITLE
Proposing changes to the mediation process

### DIFF
--- a/docs/hackers/hacker-mediation.md
+++ b/docs/hackers/hacker-mediation.md
@@ -34,4 +34,4 @@ Requesting hacker mediation triggers the following actions:
 
 While HackerOne can't guarantee resolution or override a security team's assessment, hacker mediation has been used to successfully bring items to the security teams' attention, resulting in a more favorable outcome for everyone involved.
 
-As a reminder, hacker mediation is a privilege that is reserved for hackers with 200 reputations point and signal ≥ 1. In most cases, HackerOne will not be able to mediate for reports that have been closed for over 3 months. Please respect the guidelines above and only request mediation if it's deemed absolutely necessary. Abuse of the hacker mediation process will result in this privilege being revoked from your account.
+As a reminder, hacker mediation is a privilege that is reserved for hackers without a negative signal level . In most cases, HackerOne will not be able to mediate for reports that have been closed for over 3 months. Please respect the guidelines above and only request mediation if it's deemed absolutely necessary. Abuse of the hacker mediation process will result in this privilege being revoked from your account.


### PR DESCRIPTION
Hi,
I would like to propose that the mediation process be available to anybody without a negative signal level.I believe this strikes a good balance between keeping out garbage mediation requests and allowing genuine mediation requests.A programme can erroneously close a report for a hacker submitting his first or second report thus he has no way to get mediation yet he has a genuine report.This is a real issue i have seen.
Hope you will make the changes.

Thanks.