### PR TITLE
Fix minor typos etc. in Contributing Guidelines

### DIFF
--- a/contributing-guidelines.md
+++ b/contributing-guidelines.md
@@ -6,36 +6,44 @@ You can add new articles to either the Hacker Book or the Program Book.
 #### Hacker Book
 When adding a new article, make sure you format the file such that the first several lines of the markdown file are:
 
-`---`<br>
-`title: "Title of the Article"`<br>
-`path: "/hackers/title-of-the-article.html"`<br>
-`id: "hackers/title-of-the-article"`<br>
-`---`
+```md
+---
+title: "Title of the Article"
+path: "/hackers/title-of-the-article.html"
+id: "hackers/title-of-the-article"
+---
+```
 
 #### Program Book
 When adding a new article to the program book, make sure you format the file such that the first several lines of the markdown file are:
 
-`---`<br>
-`title: "Title of the Article"`<br>
-`path: "/programs/title-of-the-article.html"`<br>
-`id: "programs/title-of-the-article"`<br>
-`---`
+```md
+---
+title: "Title of the Article"
+path: "/programs/title-of-the-article.html"
+id: "programs/title-of-the-article"
+---
+```
 
 #### Changelog Entry For a New Month
 You can also add a changelog entry for a new month that isn't listed on the changelog yet. To add a changelog entry for a new month, make sure you format the file such that the first several lines of the markdown file are:
 
-`---`<br>
-`title: "Month Year"`<br>
-`path: "/changelog/[year]/[month]"`<br>
-`date: "year-month number"`<br>
-`---`
+```md
+---
+title: "Month Year"
+path: "/changelog/[year]/[month]"
+date: "year-month number"
+---
+```
 
 Example:
-<br>`---`<br>
-`title: "November 2016"`<br>
-`path: "/changelog/2016/November"`<br>
-`date: "2016-11"`<br>
-`---`
+```md
+---
+title: "November 2016"
+path: "/changelog/2016/November"
+date: "2016-11"
+---
+```
 
 ### Github Formatting
 How do I... | Answer

--- a/contributing-guidelines.md
+++ b/contributing-guidelines.md
@@ -22,7 +22,7 @@ When adding a new article to the program book, make sure you format the file suc
 `---`
 
 #### Changelog Entry For a New Month
-You can also add a changelog entry for a new month that isn't listed on the changelog yet. To add a changelog entry for a new month, make sure you format the file such that the firs several lines of the markdown file are:
+You can also add a changelog entry for a new month that isn't listed on the changelog yet. To add a changelog entry for a new month, make sure you format the file such that the first several lines of the markdown file are:
 
 `---`<br>
 `title: "Month Year"`<br>
@@ -43,7 +43,7 @@ How do I... | Answer
 Add a link to a page within the docs site of the same book | `[Start H1 Response](start-h1-response.html)` or `[Start H1 Bounty](start-h1-bounty.html)`.
 Add a link to a page within the docs site to an article in another book | `[Start H1 Bounty](/programs/start-h1-bounty.html)`
 Add an image | `![image name](./images/signal-impact-2.png)`
-Referencing the HackerOne blog link | Use `https://hackerone.com/blog` not www.hackerone.com/blog
+Reference the HackerOne blog link | Use `https://hackerone.com/blog` not www.hackerone.com/blog
 
 ### Active Voice
 We use active voice at HackerOne as active voice is more personal and engaging vs. passive voice. In active voice, the subject does or acts upon the verb, while in passive voice, the subject is being acted upon.
@@ -60,7 +60,7 @@ In order to convey a personal and less formal voice, it's best to use contractio
 Contraction - (Yes, please use this!) | Non-Contracted Phrases (Steer away from this)
 ------------------------------------- | -----------------------------------
 can't | cannot
-don't | do no
+don't | do not
 won't | will not
 it's | it is
 they're | they are


### PR DESCRIPTION
The following typos were corrected:
- firs :arrow_right: firs**t**
- do no (don't) :arrow_right: do no**t**
- (how do I ...) referenc~~ing~~ :arrow_right: referenc**e**

As a separate commit, I also changed blocks of code so that they used markdown code blocks. The advantage of these is that
- Semantically it is clear that all of the code belongs together
- We can get syntax highlighting (optionally)
- It is easier to change the code later, especially over multiple lines (since you can just copy and paste the new code without needing to worry about adding backticks and `<br>` tags)