### PR TITLE
Update link to Ubuntu/Debian certificate install section

### DIFF
--- a/docs/hackers/hackerone-vpn-root-ca.md
+++ b/docs/hackers/hackerone-vpn-root-ca.md
@@ -10,7 +10,7 @@ Refer to these installation and configuration instructions for your platform:
 
 * [Windows](#windows)
 * [macOS](#macos)
-* [Ubuntu/Debian Linux](#ubuntu)
+* [Ubuntu/Debian Linux](#ubuntudebian-linux)
 * [Firefox](#firefox)
 
 ><i>Note: Firefox manages its own trusted certificate list, so you always need to add the root authority certificate to the browser even if you've installed it system wide.</i>


### PR DESCRIPTION
The `#ubuntu` ID doesn't exist on any of the titles, `#ubuntudebian-linux` does. This change makes sure the link to the "Ubuntu/Debian Linux" section is working correctly.