### PR TITLE
added configure alternative certificate section

### DIFF
--- a/docs/programs/single-sign-on-sso-via-saml.md
+++ b/docs/programs/single-sign-on-sso-via-saml.md
@@ -71,7 +71,7 @@ Here are some screenshots that provide additional details on Service Provider an
 ![saml_2](./images/saml-2.png)
 
 ### Configure an Alternative Certificate
-If you need to switch your identity provider or if your current X509 certificate fingerprint is expiring, you can configure an alternative certificate to avoid having your users reset their passwords during the update.
+If you need to switch your identity provider or if your current SAML certificate is expiring, you can configure an alternative SAML certificate to avoid having to disable your SSO integration during the update.
 
 > **Note:** Only the admin of the program has the ability to configure the alternative certificate.
 
@@ -88,6 +88,8 @@ To configure an alternative certificate:
 
 4. Click **Save**.
 
-You can choose to make your alternative certificate to become your primary by clicking **Promote alternative certificate to primary certificate**.
+After the alternative certificate has been configured, users will be able to authenticate through the new SAML certificate.
+
+When the primary certificate isn't used anymore, you can promote the alternative certificate to the primary by clicking **Promote alternative certificate to primary certificate**. This will enable your primary certificate to be replaced with the alternative. 
 
 ![authentication settings page with alt certificate configured](./images/alt-certificate-3.png)

--- a/docs/programs/single-sign-on-sso-via-saml.md
+++ b/docs/programs/single-sign-on-sso-via-saml.md
@@ -22,7 +22,7 @@ HackerOne supports Single Sign-On (SSO) through Security Assertion Markup Langua
 
 ### Set Up
 To configure Single Sign-On via SAML:
-1. Go to: **Program Settings > General > Authentication**.
+1. Go to **Program Settings > General > Authentication**.
 2. Click **Setup SAML** in the *Single Sign-on with SAML* section.
 
 ![saml setup](./images/saml-daisy-1.png)
@@ -69,3 +69,25 @@ Here are some screenshots that provide additional details on Service Provider an
 ![saml1](./images/saml-1.png)
 
 ![saml_2](./images/saml-2.png)
+
+### Configure an Alternative Certificate
+If you need to switch your identity provider or if your current X509 certificate fingerprint is expiring, you can configure an alternative certificate to avoid having your users reset their passwords during the update.
+
+> **Note:** Only the admin of the program has the ability to configure the alternative certificate.
+
+To configure an alternative certificate:
+
+1. Go to **Program Settings > General > Authentication**.
+2. Click **configure** next to **X509 alternative certificate**.
+
+![Authentication settings page with SAML configured](./images/alt-certificate-1.png)
+
+3. Enter the alternative certificate in the **Configure alternative certificate** window. 
+
+![configure alternative certificate modal ](./images/alt-certificate-2.png)
+
+4. Click **Save**.
+
+You can choose to make your alternative certificate to become your primary by clicking **Promote alternative certificate to primary certificate**.
+
+![authentication settings page with alt certificate configured](./images/alt-certificate-3.png)


### PR DESCRIPTION
hi @jobertabma and @bwillis - I added in a section for configuring alternative certificates on the current SSO-SAML docs page. lmk if you think it's better for it to have it's own page. 

Also quick question, in the case that a program switches identity providers, how do they go about setting up the new certificate? Do they make the certificate for the new provider the new alternative and then make it that the primary? 

