### PR TITLE
Update reputation.md

### DIFF
--- a/docs/hackers/reputation.md
+++ b/docs/hackers/reputation.md
@@ -21,6 +21,7 @@ Triaged or Resolved | +7 <br><br><i>The +7 reputation will be deducted if the re
 Duplicate of a resolved report submitted prior to the report being made public | +2
 The original report is resolved before the duplicate was filed | 0
 Informative | 0
+Self-closed N/A report | 0
 Duplicate of a self-closed N/A report | 0
 Not Applicable | -5
 Duplicate of a resolved report submitted after the report is made public | -5


### PR DESCRIPTION
I don't see where the case of a self-closed N/A report ist covered. In the current table, it appears to me that self-closed N/A reports cause a -5 reputation decrease since the report's state is 'Not Applicable'. However, self-closed reports actually don't lead to any reputation change.

Another remark: I think the case 'The original report is resolved before the duplicate was filed' might not be clear enough. I would suggest a different description, but I don't even understand how exactly the case is different from 'Duplicate of a resolved report submitted prior to the report being made public'.