### PR TITLE
Change example reports in Quality Reports page

### DIFF
--- a/docs/hackers/quality-reports.md
+++ b/docs/hackers/quality-reports.md
@@ -17,8 +17,10 @@ It’s best to be comprehensive, yet concise as security teams need to have all 
 
 ### Examples
 Here are some examples of publicly disclosed examples of good reports:
-* [Twitter disclosed on HackerOne: URGENT - Subdomain Takeover](https://hackerone.com/reports/32825)
-* [Shopify disclosed on HackerOne: Attention! Remote Code Execution](https://hackerone.com/reports/73567)
+* [Shopify disclosed on HackerOne: Remote Code Execution on kitcrm using bulk customer update of Priority Products](https://hackerone.com/reports/422944)
+* [Semrush disclosed on HackerOne: XXE in Site Audit function exposing file and directory contents](https://hackerone.com/reports/312543)
+* [Shopify disclosed on HackerOne: Stored XSS in blog comments through Shopify API](https://hackerone.com/reports/192210)
+* [QIWI disclosed on HackerOne: SQL injection on contactws.contact-sys.com in TScenObject action ScenObjects leads to remote code execution](https://hackerone.com/reports/816254)
 
 Some great resources for vulnerability report best practices are:
 * [Dropbox Bug Bounty Program: Best Practices](https://blogs.dropbox.com/tech/2015/08/dropbox-bug-bounty-program-best-practices-2/)


### PR DESCRIPTION
As discussed in slack: The example reports had some sort of attention grabbing titles ("URGENT", "Attention!") and with all due respect to the authors of those report, it's really not something I think should be encouraged and shown in an example of a good report for beginners.

I modified the list with 2 other reports from the same Hackers and added 2 other ones for good measure. I picked that specific Semrush report from ajxchapman (and not another perhaps more technically impressive one) because it's a bug type many beginners will be familiar with and honoki's QIWI report shows polite interaction with the program when faced with a disagreement on top of being a great report.