### PR TITLE
Changed 'Report Mediation' for 'Request Mediation'

### DIFF
--- a/docs/hackers/report-actions.md
+++ b/docs/hackers/report-actions.md
@@ -24,7 +24,7 @@ When the report is in the triaged state, you can only add comments to the report
 ### Request Mediation
 You can also request for mediation from HackerOne in extreme cases when all normal discussions with the team have been attempted and there has been no satisfactory resolution.
 
-To request mediation, select the **Report abuse** option, and select **Report Mediation**.
+To request mediation, select the **Report abuse** option, and select **Request Mediation**.
 
 ![report-actions-hacker-3](./images/report-actions-hacker-3.png)
 


### PR DESCRIPTION
There was a small *error in the description* in the topic **"Report Actions"**, where the intent was **"Request Mediation"** from HackerOne, but it said **"Report Mediation"**.

**Below are images of the change:**

In the official documentation:
![old](https://user-images.githubusercontent.com/47436525/125180102-a3fd9f00-e1e5-11eb-8a1c-ec9a301b80f0.png)

The change:
![new](https://user-images.githubusercontent.com/47436525/125180103-a4963580-e1e5-11eb-92dc-a5ec1ccf6e9d.png)

