### PR TITLE
Fix sidebar link to the Vacations page

### DIFF
--- a/src/pages/programs/programs-nav.yaml
+++ b/src/pages/programs/programs-nav.yaml
@@ -160,7 +160,7 @@
     - title: Retesting
       path: /programs/retesting.html
     - title: Vacations
-      path: /programs/vacations.md
+      path: /programs/vacations.html
 - title: Integrations
   items:
     - title: Supported Integrations


### PR DESCRIPTION
The link in the sidebar to Vacations, in the Programs docs under Reports, is currently broken because it tries to link to `vacations.md` instead of `vacations.html`, and this PR fixes it.