### PR TITLE
Rename and fix typo on team member eligibility page

### DIFF
--- a/docs/programs/team-member-eligibility.md
+++ b/docs/programs/team-member-eligibility.md
@@ -10,4 +10,4 @@ To set this up, visit the Authentication page under your program settings.
 
 ![team-member-eligibility](./images/team-member-eligibility.png)
 
-><i>Note: When enabling SSO with SAML, eligibility will automatically be enabled with your SSO damains</i>.
+><i>Note: When enabling SSO with SAML, eligibility will automatically be enabled with your SSO domains</i>.


### PR DESCRIPTION
* Rename set-up-team-member-eligibility --> team-member-eligibility
* Fix typo damains --> domains