### PR TITLE
Added the frankfurt location to the VPN docs

### DIFF
--- a/docs/hackers/configure-the-hackerone-vpn.md
+++ b/docs/hackers/configure-the-hackerone-vpn.md
@@ -30,10 +30,11 @@ To join a program that uses VPN and to set up the HackerOne Gateway (VPN):
 
 ![banner to configure VPN](./images/gateway-1.png)
 
-5. Wait a couple of seconds for HackerOne to create your VPN configurations and add Gateway locations. You’ll see these 2 Gateway locations once your VPNs have been configured:
+5. Wait a couple of seconds for HackerOne to create your VPN configurations and add Gateway locations. You’ll see these 3 Gateway locations once your VPNs have been configured:
 <ul><li>Oregon, USA
-<li>Mumbai, India</li></ul>
-<i>These are currently the only 2 regions where HackerOne has Gateways instances available. Your latency is determined by how close you are to a Gateway location. The closer you are to a location, the better your latency.</i>
+<li>Mumbai, India</li>
+<li>Frankfurt, Germany</li></ul>
+<i>These are currently the only 3 regions where HackerOne has Gateways instances available. Your latency is determined by how close you are to a Gateway location. The closer you are to a location, the better your latency.</i>
 
 ![image](./images/gateway-2.png)
 


### PR DESCRIPTION
I noticed that frankfurt wasn’t added yet to the docs, while i’m able to download the vpn config for frankfurt, so i added it