### PR TITLE
Try new node for deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.DEPLOY_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ public/
 .DS_Store
 npm-debug.log
 yarn-error.log
+*.icloud


### PR DESCRIPTION
Node v12 is deprecated, using suggestion from https://github.com/enriikke/gatsby-gh-pages-action/issues/76