### PR TITLE
feat(63090): add redirects from all /programs to /organizations

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,6 +41,11 @@ exports.createPages = ({ graphql, actions }) => {
       let template;
       if (node.frontmatter.path.includes("/organizations")) {
         template = programsTemplate;
+        createRedirect({
+          fromPath: node.frontmatter.path.replace("/organizations", "/programs"),
+          toPath: node.frontmatter.path,
+          isPermanent: true,
+        });
       } else if (node.frontmatter.path.includes("/hackers")) {
         template = hackersTemplate;
       } else if (node.frontmatter.path.includes("/changelog")) {


### PR DESCRIPTION
# Description

This fix adds in redirects for all `/program/` and `/program/*` subpages, to matching `/organization` pages by using the page nodes we're getting from the `allMarkdownRemark`.

# Testing

- You can test this by running the production build locally via `yarn build; yarn serve`, and seeing that navigating to any /program pages and subpages redirect as expected at http://localhost:9000
- e.g.: http://localhost:9000/programs/supported-integrations.html redirects to http://localhost:9000/organizations/supported-integrations.html