### PR TITLE
Make status banner slighly smaller so it does not wrap

### DIFF
--- a/src/components/status/status.scss
+++ b/src/components/status/status.scss
@@ -45,6 +45,7 @@ $green: #2ecc71;
   display: inline-block;
   color: $daisy-white;
   text-decoration: none;
+  font-size: .9em;
 
   &:active {
     color: $daisy-white;


### PR DESCRIPTION
Before:
<img width="497" alt="Screenshot 2023-09-21 at 17 00 07" src="https://github.com/Hacker0x01/docs.hackerone.com/assets/245096/a860e310-0489-4f69-afea-62c5a8e101d4">


After:
<img width="678" alt="Screenshot 2023-09-21 at 16 58 37" src="https://github.com/Hacker0x01/docs.hackerone.com/assets/245096/dc984c92-947b-4567-abba-07a1be1b9b85">
