### PR TITLE
Minor reformat to clarify the label on the button to create a new PSR 

### DIFF
--- a/docs/changelog/2023/september.md
+++ b/docs/changelog/2023/september.md
@@ -5,7 +5,7 @@ date: "2023-09"
 ---
 
 ### Program Status Reports
-Program Status Reports are available to all Bounty and Response customers! Go to Analytics > Program Status Reports and click **Create New to use Program Status Reports.** This will bring you to the report preview, where you can name your report, select the input date range for your report, and apply content filters via the menu in the upper right-hand corner of the page. Once satisfied with the contents of the report, click the **Generate Report** button to save it and return to the list view for your reports. 
+Program Status Reports are available to all Bounty and Response customers! Go to Analytics > Program Status Reports and click **Create New** to use Program Status Reports. This will bring you to the report preview, where you can name your report, select the input date range for your report, and apply content filters via the menu in the upper right-hand corner of the page. Once satisfied with the contents of the report, click the **Generate Report** button to save it and return to the list view for your reports. 
 
 ![program status report example](/images/program-status-report.png)
 


### PR DESCRIPTION
The September 2023 changelog introduces Program Status Reports along with a basic walkthrough of the onboarding user flow. There is a minor formatting error, though.

-----

### Current behavior:![image](https://github.com/Hacker0x01/docs.hackerone.com/assets/10716475/ec9ed482-456d-4cdb-8d3b-f195f2f001a1)


### Proposed behavior:![image](https://github.com/Hacker0x01/docs.hackerone.com/assets/10716475/1e8da751-4326-4663-9c40-2e3e04fa31e7)


----
<details>
<summary><h2>👤</h2><h3>User Story</summary>

> <strong>As an idiot, I want idiot-proof docs so that </strong>@emgreen33<strong> will forget— if only for a moment — that I'm an idiot.</h3>
</strong>
